### PR TITLE
Remove use of ioutil package

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,7 +7,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
 	"os"
@@ -92,7 +91,7 @@ func cliOptions(stdout io.Writer, args []string) (*options, error) {
 	if v {
 		verbose = os.Stderr
 	} else {
-		verbose = ioutil.Discard
+		verbose = io.Discard
 	}
 
 	if err := flags.Parse(args); err != nil {
@@ -125,7 +124,7 @@ func githubActionOptions() (*options, error) {
 		return nil, fmt.Errorf("env var GITHUB_EVENT_PATH not set")
 	}
 
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read GitHub event json %s: %s", path, err)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -46,7 +45,7 @@ func TestMain(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 
-			gitroot, err := ioutil.TempDir("", "codenotify")
+			gitroot, err := os.MkdirTemp("", "codenotify")
 			if err != nil {
 				t.Fatalf("unable to create temporary directory: %s", err)
 			}
@@ -62,7 +61,7 @@ func TestMain(t *testing.T) {
 					t.Fatalf("unable to make directory %s: %s", dir, err)
 				}
 
-				if err := ioutil.WriteFile(file, []byte(content), 0666); err != nil {
+				if err := os.WriteFile(file, []byte(content), 0666); err != nil {
 					t.Fatalf("unable to write file %s: %s", file, err)
 				}
 			}


### PR DESCRIPTION
Removes usage of the deprecated ioutil package as described [here](https://golang.org/doc/go1.16#ioutil)

[_Created by Sourcegraph batch change `rslade/deprecate-ioutil`._](https://k8s.sgdev.org/users/rslade/batch-changes/deprecate-ioutil)