### PR TITLE
Ensure there’s a separate PR comment when filename is different

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -146,7 +146,7 @@ func TestWriteNotifications(t *testing.T) {
 			},
 			notifs: nil,
 			output: []string{
-				"<!-- codenotify report -->",
+				"<!-- codenotify:CODENOTIFY report -->",
 				"[Codenotify](https://github.com/sourcegraph/codenotify): Notifying subscribers in CODENOTIFY files for diff a...b.",
 				"",
 				"No notifications.",
@@ -179,7 +179,7 @@ func TestWriteNotifications(t *testing.T) {
 				"@js": {"file.js", "dir/file.js"},
 			},
 			output: []string{
-				"<!-- codenotify report -->",
+				"<!-- codenotify:CODENOTIFY report -->",
 				"[Codenotify](https://github.com/sourcegraph/codenotify): Notifying subscribers in CODENOTIFY files for diff a...b.",
 				"",
 				"| Notify | File(s) |",


### PR DESCRIPTION
When testing on https://github.com/sourcegraph/sourcegraph/pull/30395, I discovered that if we run Codenotify twice on the same PR (i.e., once for CODENOTIFY, once for OWNERS), it will merge the contents together.

This PR updates the tool so that it maintains a separate comment per PR+filename.