### PR TITLE
notify: support subscriber threshold to prevent broad spamming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /codenotify
 /coverage.txt
+.idea

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ jobs:
 #         # Filename in which file subscribers are defined, default is 'CODENOTIFY'
 #         filename: 'CODENOTIFY'
 #         # The threshold of notifying subscribers to prevent broad spamming, 0 to disable (default)
-#         subscriber_threshold: '10'
+#         subscriber-threshold: '10'
 ```
 
 ## CODENOTIFY files

--- a/README.md
+++ b/README.md
@@ -46,12 +46,17 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: sourcegraph/codenotify@v0.4
+      - uses: sourcegraph/codenotify@v0.5
         env:
           # secrets.GITHUB_TOKEN is available by default, but it won't allow CODENOTIFY to mention GitHub teams.
           # If you want CODENOTIFY to be able to mention teams, then you need to create a personal access token
           # (https://github.com/settings/tokens) with scopes: repo, read:org.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#       with:
+#         # Filename in which file subscribers are defined, default is 'CODENOTIFY'
+#         filename: 'CODENOTIFY'
+#         # The threshold of notifying subscribers to prevent broad spamming, 0 to disable (default)
+#         subscriber_threshold: '10'
 ```
 
 ## CODENOTIFY files

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: 'Filename in which file subscribers are defined'
     required: false
     default: 'CODENOTIFY'
+  subscriber_threshold:
+    description: 'The threshold of notifying subscribers to prevent broad spamming, 0 to disable'
+    required: false
+    default: '0'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ inputs:
     description: 'Filename in which file subscribers are defined'
     required: false
     default: 'CODENOTIFY'
-  subscriber_threshold:
+  subscriber-threshold:
     description: 'The threshold of notifying subscribers to prevent broad spamming, 0 to disable'
     required: false
     default: '0'

--- a/main.go
+++ b/main.go
@@ -387,7 +387,7 @@ func markdownCommentTitle(filename string) string {
 
 func (o *options) writeNotifications(w io.Writer, notifs map[string][]string) error {
 	if o.subscriberThreshold > 0 && len(notifs) > o.subscriberThreshold {
-		fmt.Fprintf(w, "The number of notifying subscribers (%d) has exceeded the threshold (%d).\n", len(notifs), o.subscriberThreshold)
+		fmt.Fprintf(w, "Not notifying subscribers because the number of notifying subscribers (%d) has exceeded the threshold (%d).\n", len(notifs), o.subscriberThreshold)
 		return nil
 	}
 

--- a/main.go
+++ b/main.go
@@ -88,7 +88,7 @@ func cliOptions(stdout io.Writer, args []string) (*options, error) {
 	flags.StringVar(&opts.headRef, "headRef", "HEAD", "The head ref to use when computing the file diff.")
 	flags.StringVar(&opts.format, "format", "text", "The format of the output: text or markdown")
 	flags.StringVar(&opts.filename, "filename", "CODENOTIFY", "The filename in which file subscribers are defined")
-	flags.IntVar(&opts.subscriberThreshold, "subscriber_threshold", 0, "The threshold of notifying subscribers")
+	flags.IntVar(&opts.subscriberThreshold, "subscriber-threshold", 0, "The threshold of notifying subscribers")
 	v := *flags.Bool("verbose", false, "Verbose messages printed to stderr")
 
 	if v {

--- a/main.go
+++ b/main.go
@@ -88,6 +88,7 @@ func cliOptions(stdout io.Writer, args []string) (*options, error) {
 	flags.StringVar(&opts.headRef, "headRef", "HEAD", "The head ref to use when computing the file diff.")
 	flags.StringVar(&opts.format, "format", "text", "The format of the output: text or markdown")
 	flags.StringVar(&opts.filename, "filename", "CODENOTIFY", "The filename in which file subscribers are defined")
+	flags.IntVar(&opts.subscriberThreshold, "subscriber_threshold", 0, "The threshold of notifying subscribers")
 	v := *flags.Bool("verbose", false, "Verbose messages printed to stderr")
 
 	if v {
@@ -370,13 +371,14 @@ func graphql(query string, variables map[string]interface{}, responseData interf
 }
 
 type options struct {
-	cwd      string
-	baseRef  string
-	headRef  string
-	format   string
-	filename string
-	author   string
-	print    func(notifs map[string][]string) error
+	cwd                 string
+	baseRef             string
+	headRef             string
+	format              string
+	filename            string
+	subscriberThreshold int
+	author              string
+	print               func(notifs map[string][]string) error
 }
 
 func markdownCommentTitle(filename string) string {
@@ -384,7 +386,12 @@ func markdownCommentTitle(filename string) string {
 }
 
 func (o *options) writeNotifications(w io.Writer, notifs map[string][]string) error {
-	subs := []string{}
+	if o.subscriberThreshold > 0 && len(notifs) > o.subscriberThreshold {
+		fmt.Fprintf(w, "The number of notifying subscribers (%d) has exceeded the threshold (%d).\n", len(notifs), o.subscriberThreshold)
+		return nil
+	}
+
+	subs := make([]string, 0, len(notifs))
 	for sub := range notifs {
 		subs = append(subs, sub)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -216,6 +216,19 @@ func TestWriteNotifications(t *testing.T) {
 			},
 			err: "unsupported format: pdf",
 		},
+		{
+			name: "exceeded subscriber threshold",
+			opts: options{
+				subscriberThreshold: 1,
+			},
+			notifs: map[string][]string{
+				"@go": {"file.go", "dir/file.go"},
+				"@js": {"file.js", "dir/file.js"},
+			},
+			output: []string{
+				"The number of notifying subscribers (2) has exceeded the threshold (1).",
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/main_test.go
+++ b/main_test.go
@@ -226,7 +226,7 @@ func TestWriteNotifications(t *testing.T) {
 				"@js": {"file.js", "dir/file.js"},
 			},
 			output: []string{
-				"The number of notifying subscribers (2) has exceeded the threshold (1).",
+				"Not notifying subscribers because the number of notifying subscribers (2) has exceeded the threshold (1).",
 			},
 		},
 	}


### PR DESCRIPTION
Adds a new input option `subscriber-threshold` to limit notifying a large number of subscribes in which cases causes more spamming than high signal. This does not change the default behavior (i.e. notify all).

A follow up PR will be made to update "sourcegraph/sourcegraph" to set a reasonable threshold.