### PR TITLE
Read the GitHub Action env var for subscriber threshold

### DIFF
--- a/main.go
+++ b/main.go
@@ -161,13 +161,16 @@ func githubActionOptions() (*options, error) {
 		return nil, fmt.Errorf("env var INPUT_FILENAME not set")
 	}
 
+	subscriberThreshold, _ := strconv.Atoi(os.Getenv("INPUT_SUBSCRIBER-THRESHOLD"))
+
 	o := &options{
-		cwd:      cwd,
-		format:   "markdown",
-		filename: filename,
-		baseRef:  event.PullRequest.Base.Sha,
-		headRef:  event.PullRequest.Head.Sha,
-		author:   "@" + event.PullRequest.User.Login,
+		cwd:                 cwd,
+		format:              "markdown",
+		filename:            filename,
+		subscriberThreshold: subscriberThreshold,
+		baseRef:             event.PullRequest.Base.Sha,
+		headRef:             event.PullRequest.Head.Sha,
+		author:              "@" + event.PullRequest.User.Login,
 	}
 	o.print = commentOnGitHubPullRequest(o, event.PullRequest.NodeID)
 	return o, nil


### PR DESCRIPTION
The [previous attempt](https://github.com/sourcegraph/codenotify/pull/18) only added a CLI argument which is not used at all when running as a GitHub Action.