### PR TITLE
Update docs for authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,6 @@ If you want Codenotify to be able to mention teams, then you need to:
     + GITHUB_TOKEN: ${{ secrets.CODENOTIFY_GITHUB_TOKEN }}
     ```
     
-##### Behavior on forks
-
-Codenotify does not work on forks
-
 ## CODENOTIFY files
 
 CODENOTIFY files contain rules that define who gets notified when files change.

--- a/README.md
+++ b/README.md
@@ -42,15 +42,14 @@ jobs:
   codenotify:
     runs-on: ubuntu-latest
     name: codenotify
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: sourcegraph/codenotify@v0.5
         env:
-          # secrets.GITHUB_TOKEN is available by default, but it won't allow CODENOTIFY to mention GitHub teams.
-          # If you want CODENOTIFY to be able to mention teams, then you need to create a personal access token
-          # (https://github.com/settings/tokens) with scopes: repo, read:org.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 #       with:
 #         # Filename in which file subscribers are defined, default is 'CODENOTIFY'
@@ -58,6 +57,24 @@ jobs:
 #         # The threshold of notifying subscribers to prevent broad spamming, 0 to disable (default)
 #         subscriber-threshold: '10'
 ```
+
+##### GITHUB_TOKEN
+
+The default configuration above uses [automatic token authentication](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret), but there are some limitations with this method of authentication:
+* Codenotify will not be able to mention teams.
+* Codenotify will fail when run on repository forks.
+
+If you want Codenotify to be able to mention teams or if you want Codenotify to be able to run on forks, then you need to:
+1. Create a [personal access token](https://github.com/settings/tokens) with the following permissions:
+    * `read:org` is necessary to mention teams
+    * `repo` is necessary if you want to use Codenotify with private repositories. Otherwise, `public_repo` is sufficient.
+    * If you are an organization, consider creating the PAT under a separate bot account.
+2. Store the PAT as a secret in your repository or organization (recommend naming this `CODENOTIFY_GITHUB_TOKEN`)
+3. Update `.github/workflows/codenotify.yml` to use the secret you just created. For example:
+    ```diff
+    - GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    + GITHUB_TOKEN: ${{ secrets.CODENOTIFY_GITHUB_TOKEN }}
+    ```
 
 ## CODENOTIFY files
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Add `.github/workflows/codenotify.yml` to your repository with the following con
 ```yaml
 name: codenotify
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, ready_for_review]
 
 jobs:
@@ -60,11 +60,9 @@ jobs:
 
 ##### GITHUB_TOKEN
 
-The default configuration above uses [automatic token authentication](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret), but there are some limitations with this method of authentication:
-* Codenotify will not be able to mention teams.
-* Codenotify will fail when run on repository forks.
+The default configuration above uses [automatic token authentication](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret), but a limitation with this method of authentication is that Codenotify will not be able to mention teams.
 
-If you want Codenotify to be able to mention teams or if you want Codenotify to be able to run on forks, then you need to:
+If you want Codenotify to be able to mention teams, then you need to:
 1. Create a [personal access token](https://github.com/settings/tokens) with the following permissions:
     * `read:org` is necessary to mention teams
     * `repo` is necessary if you want to use Codenotify with private repositories. Otherwise, `public_repo` is sufficient.
@@ -75,6 +73,10 @@ If you want Codenotify to be able to mention teams or if you want Codenotify to 
     - GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     + GITHUB_TOKEN: ${{ secrets.CODENOTIFY_GITHUB_TOKEN }}
     ```
+    
+##### Behavior on forks
+
+Codenotify does not work on forks
 
 ## CODENOTIFY files
 

--- a/main.go
+++ b/main.go
@@ -341,6 +341,9 @@ func graphql(query string, variables map[string]interface{}, responseData interf
 	}
 
 	token := os.Getenv("GITHUB_TOKEN")
+	if token == "" {
+		return fmt.Errorf("GITHUB_TOKEN is not set")
+	}
 	req.Header.Set("Authorization", "bearer "+token)
 
 	reqdump, err := httputil.DumpRequestOut(req, true)


### PR DESCRIPTION
Changes
* Grant write permissions on pull requests for the default GITHUB_TOKEN provided to this GitHub action
* `pull_request_target` is necessary for tokens in forks to be able to have write permissions
* Explicit error message when GITHUB_TOKEN is missing
* Add docs when personal access token is necessary

Related to https://github.com/sourcegraph/codenotify/issues/19#issuecomment-1175943036