### PR TITLE
Fix verbose option in CLI mode

### DIFF
--- a/main.go
+++ b/main.go
@@ -103,16 +103,17 @@ func cliOptions(stdout io.Writer, args []string) (*options, error) {
 	flags.StringVar(&opts.format, "format", "text", "The format of the output: text or markdown")
 	flags.StringVar(&opts.filename, "filename", "CODENOTIFY", "The filename in which file subscribers are defined")
 	flags.IntVar(&opts.subscriberThreshold, "subscriber-threshold", 0, "The threshold of notifying subscribers")
-	v := *flags.Bool("verbose", false, "Verbose messages printed to stderr")
+	var v bool
+	flags.BoolVar(&v, "verbose", false, "Verbose messages printed to stderr")
+
+	if err := flags.Parse(args); err != nil {
+		return nil, err
+	}
 
 	if v {
 		verbose = os.Stderr
 	} else {
 		verbose = ioutil.Discard
-	}
-
-	if err := flags.Parse(args); err != nil {
-		return nil, err
 	}
 
 	opts.print = func(notifs map[string][]string) error {

--- a/main_test.go
+++ b/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -124,6 +125,37 @@ func TestMain(t *testing.T) {
 			expectedStdout = strings.ReplaceAll(expectedStdout, "$headRef", headRef)
 			if stdout.String() != expectedStdout {
 				t.Errorf("want stdout:\n%s\ngot:\n%s", expectedStdout, stdout.String())
+			}
+		})
+	}
+}
+
+func TestCliOptions(t *testing.T) {
+	var originalVerbose io.Writer = verbose
+	defer func() { verbose = originalVerbose }()
+	tests := []struct {
+		name    string
+		args    []string
+		verbose io.Writer
+	}{
+		{
+			name:    "no arguments",
+			args:    []string{},
+			verbose: ioutil.Discard,
+		},
+		{
+			name:    "verbose option",
+			args:    []string{"-verbose"},
+			verbose: os.Stderr,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			stdout := &bytes.Buffer{}
+			cliOptions(stdout, test.args)
+			if verbose != test.verbose {
+				t.Errorf("expected verbose to be %v; got %v", test.verbose, verbose)
 			}
 		})
 	}


### PR DESCRIPTION
Before, `v` would always be false, so the `-verbose` option never worked.