### PR TITLE
Use errors.Is/errors.As instead of == comparisons against errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -485,7 +486,7 @@ func subscribers(fs FS, path string, notifyFilename string) ([]string, error) {
 
 		rulefile, err := fs.Open(rulefilepath)
 		if err != nil {
-			if err == os.ErrNotExist {
+			if errors.Is(err, os.ErrNotExist) {
 				continue
 			}
 			return nil, err


### PR DESCRIPTION
This change replaces direct `==`/`!=` comparisons against error values with the
standard library helpers `errors.Is` (for sentinel error values) and `errors.As`
(for error types).

Direct comparison breaks when an error is wrapped (e.g. with `fmt.Errorf("...: %w", err)`),
whereas `errors.Is`/`errors.As` traverse the wrap chain.

Notes:
- Comparisons against `nil` are intentionally left unchanged.
- Test files, vendored code, and generated code were not modified.

[_Created by Sourcegraph batch change `bahrmichael/432ac474-d2a7-4950-b17f-2a1b1fe59e87`._](https://sourcegraph.sourcegraph.com/users/bahrmichael/batch-changes/432ac474-d2a7-4950-b17f-2a1b1fe59e87)