### PR TITLE
go: upgrade to Go 1.26 and modernize

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,5 +8,5 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.1'
+          go-version: '1.26.4'
       - run: go test -coverprofile coverage.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15-alpine as builder
+FROM golang:1.26.4-alpine as builder
 
 #ENV CGO_ENABLED=0
 WORKDIR /build

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/sourcegraph/codenotify
 
-go 1.15
+go 1.26.4

--- a/main.go
+++ b/main.go
@@ -142,7 +142,7 @@ func githubActionOptions() (*options, error) {
 		return nil, fmt.Errorf("env var GITHUB_EVENT_PATH not set")
 	}
 
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read GitHub event json %s: %s", path, err)
 	}
@@ -226,7 +226,7 @@ func updateComment(id, body string) error {
 				clientMutationId
 			}
 		}`,
-		map[string]interface{}{
+		map[string]any{
 			"id":   id,
 			"body": body,
 		},
@@ -245,7 +245,7 @@ func addComment(subjectId, body string) error {
 				clientMutationId
 			}
 		}`,
-		map[string]interface{}{
+		map[string]any{
 			"subjectId": subjectId,
 			"body":      body,
 		},
@@ -271,7 +271,7 @@ func commitCount(prNodeID string) (int, error) {
 				}
 			}
 		}`,
-		map[string]interface{}{
+		map[string]any{
 			"nodeId": prNodeID,
 		},
 		&data,
@@ -310,7 +310,7 @@ func existingCommentId(prNodeID string, filename string) (string, error) {
 				}
 			}
 		}`,
-		map[string]interface{}{
+		map[string]any{
 			"nodeId": prNodeID,
 		},
 		&data,
@@ -328,8 +328,8 @@ func existingCommentId(prNodeID string, filename string) (string, error) {
 	return "", nil
 }
 
-func graphql(query string, variables map[string]interface{}, responseData interface{}) error {
-	reqbody, err := json.Marshal(map[string]interface{}{
+func graphql(query string, variables map[string]any, responseData any) error {
+	reqbody, err := json.Marshal(map[string]any{
 		"query":     query,
 		"variables": variables,
 	})
@@ -370,7 +370,7 @@ func graphql(query string, variables map[string]interface{}, responseData interf
 	}
 
 	response := struct {
-		Data   interface{}
+		Data   any
 		Errors []struct {
 			Type    string   `json:"type"`
 			Path    []string `json:"path"`

--- a/main_test.go
+++ b/main_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"io/fs"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -48,7 +49,7 @@ func TestMain(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 
-			gitroot, err := ioutil.TempDir("", "codenotify")
+			gitroot, err := os.MkdirTemp("", "codenotify")
 			if err != nil {
 				t.Fatalf("unable to create temporary directory: %s", err)
 			}
@@ -64,7 +65,7 @@ func TestMain(t *testing.T) {
 					t.Fatalf("unable to make directory %s: %s", dir, err)
 				}
 
-				if err := ioutil.WriteFile(file, []byte(content), 0666); err != nil {
+				if err := os.WriteFile(file, []byte(content), 0666); err != nil {
 					t.Fatalf("unable to write file %s: %s", file, err)
 				}
 			}


### PR DESCRIPTION
Upgrades this repository to the latest Go 1.26 release (go1.26.4) across its build,
CI, and release configuration, then runs `go fix ./...` twice (Go 1.26's analyzer-based
modernizers) to apply safe, automatic modernizations enabled by the new language version.

Generated this change with a Sourcegraph batch change.

[_Created by Sourcegraph agentic batch change._](https://sourcegraph.sourcegraph.com/batch-change-agents/172)